### PR TITLE
Old style constructor definition is not working with namespaces

### DIFF
--- a/PHPTrie/Trie.php
+++ b/PHPTrie/Trie.php
@@ -42,7 +42,7 @@ class Trie
      *
      * @param mixed $value This is for internal use
      */
-    public function Trie($value = null)
+    public function __construct($value = null)
     {
         $this->value = $value;
     }


### PR DESCRIPTION
The constructor within old style is never calls if class is inside of namespace.
