### PR TITLE
Fixing 'add' docblock

### DIFF
--- a/PHPTrie/Trie.php
+++ b/PHPTrie/Trie.php
@@ -50,9 +50,9 @@ class Trie
     /**
      * Add value to the trie
      *
-     * @param $string The key
-     * @param $value The value
-     * @param bool $overWrite Overwrite existing value
+     * @param string $string    The key
+     * @param string $value     The value
+     * @param bool   $overWrite Overwrite existing value
      */
     public function add($string, $value, $overWrite=true)
     {


### PR DESCRIPTION
The docblock for the add method was missing string parameters which was resulting in incorrect IDE hinting. Added parameter type to block.

Solves #4 
