### PR TITLE
Make Trie compatible with var_export()

### DIFF
--- a/PHPTrie/Trie.php
+++ b/PHPTrie/Trie.php
@@ -200,4 +200,12 @@ class Trie
 
         return null;
     }
+
+    public static function __set_state($state)
+    {
+        $t = new self;
+        $t->trie = $state['trie'];
+        $t->value = $state['value'];
+        return $t;
+    }
 }


### PR DESCRIPTION
I needed this so I could "cache" a big 300 MB Trie into a PHP data struct that could be stored on disk and included in other scripts (which only takes a few seconds) without having to build the Trie all the time (which takes several minutes).